### PR TITLE
Close ports on finished scanning

### DIFF
--- a/src/pyglaze/device/ampcom.py
+++ b/src/pyglaze/device/ampcom.py
@@ -105,9 +105,7 @@ class _ForceAmpCom:
 
     def __del__(self: _ForceAmpCom) -> None:
         """Closes connection when class instance goes out of scope."""
-        with contextlib.suppress(AttributeError):
-            # If the serial device does not exist, self.__ser is never created - hence catch
-            self.__ser.close()
+        self.disconnect()
 
     def write_all(self: _ForceAmpCom) -> list[str]:
         responses = []
@@ -190,6 +188,12 @@ class _ForceAmpCom:
             output_array[iteration, 2] = angle
         return output_array
 
+    def disconnect(self: _ForceAmpCom) -> None:
+        """Closes connection."""
+        with contextlib.suppress(AttributeError):
+            # If the serial device does not exist, self.__ser is never created - hence catch
+            self.__ser.close()
+
     def _encode_send_response(self: _ForceAmpCom, command: str) -> str:
         self._encode_and_send(command)
         return self._get_response()
@@ -264,9 +268,7 @@ class _LeAmpCom:
 
     def __del__(self: _LeAmpCom) -> None:
         """Closes connection when class instance goes out of scope."""
-        with contextlib.suppress(AttributeError):
-            # If the serial device does not exist, self.__ser is never created - hence catch
-            self.__ser.close()
+        self.disconnect()
 
     def write_all(self: _LeAmpCom) -> list[str]:
         responses: list[str] = []
@@ -293,6 +295,12 @@ class _LeAmpCom:
 
         radii, angles = self._convert_to_r_angle(Xs, Ys)
         return self.START_COMMAND, np.array(times), np.array(radii), np.array(angles)
+
+    def disconnect(self: _LeAmpCom) -> None:
+        """Closes connection when class instance goes out of scope."""
+        with contextlib.suppress(AttributeError):
+            # If the serial device does not exist, self.__ser is never created - hence catch
+            self.__ser.close()
 
     @cached_property
     def _intervals(self: _LeAmpCom) -> list[Interval]:

--- a/src/pyglaze/devtools/mock_device.py
+++ b/src/pyglaze/devtools/mock_device.py
@@ -28,6 +28,7 @@ class MockDevice(ABC):
         n_fails: float = np.inf,
         *,
         empty_responses: bool = False,
+        instant_response: bool = False,
     ) -> None:
         pass
 
@@ -42,6 +43,8 @@ class ForceMockDevice(MockDevice):
         self: ForceMockDevice,
         fail_after: float = np.inf,
         n_fails: float = np.inf,
+        *,
+        instant_response: bool = False,
     ) -> None:
         self.fail_after = fail_after
         self.fails_wanted = n_fails
@@ -50,6 +53,7 @@ class ForceMockDevice(MockDevice):
         self.rng = np.random.default_rng()
         self.valid_input = True
         self.experiment_running = False
+        self.instant_response = instant_response
 
         self._periods = None
         self._frequency = None
@@ -131,7 +135,8 @@ class ForceMockDevice(MockDevice):
         for _ in range(self.in_waiting):
             return_string += self.__create_random_datapoint
         return_string += "!D,DONE\\r"
-        sleep(self.sweep_length * 1e-3)
+        if not self.instant_response:
+            sleep(self.sweep_length * 1e-3)
         self.n_scans += 1
         if self.n_scans > self.fail_after and self.n_failures < self.fails_wanted:
             self.n_failures += 1
@@ -190,6 +195,7 @@ class LeMockDevice(MockDevice):
         n_fails: float = np.inf,
         *,
         empty_responses: bool = False,
+        instant_response: bool = False,
     ) -> None:
         self.fail_after = fail_after
         self.fails_wanted = n_fails
@@ -204,6 +210,7 @@ class LeMockDevice(MockDevice):
         self.scanning_list: list[float] | None = None
         self._scan_start_time: float | None = None
         self.empty_responses = empty_responses
+        self.instant_response = instant_response
 
     def write(self: LeMockDevice, input_bytes: bytes) -> None:
         """Mock-write to the serial connection."""
@@ -374,6 +381,8 @@ def _mock_device_factory(config: DeviceConfiguration) -> MockDevice:
         return mock_class(fail_after=0)
     if config.amp_port == "mock_device":
         return mock_class()
+    if config.amp_port == "mock_device_instant":
+        return mock_class(instant_response=True)
     if config.amp_port == "mock_device_fail_first_scan":
         return mock_class(fail_after=0, n_fails=1)
     if config.amp_port == "mock_device_empty_responses":

--- a/src/pyglaze/devtools/mock_device.py
+++ b/src/pyglaze/devtools/mock_device.py
@@ -372,6 +372,7 @@ def list_mock_devices() -> list[str]:
         "mock_device_scan_should_fail",
         "mock_device_fail_first_scan",
         "mock_device_empty_responses",
+        "mock_device_instant",
     ]
 
 

--- a/src/pyglaze/scanning/_asyncscanner.py
+++ b/src/pyglaze/scanning/_asyncscanner.py
@@ -127,6 +127,7 @@ class _AsyncScanner:
                 parent_conn.send(
                     _ScannerHealth(is_alive=False, is_healthy=False, error=e)
                 )
+                scanner.disconnect()
                 break
 
             try:

--- a/src/pyglaze/scanning/_exceptions.py
+++ b/src/pyglaze/scanning/_exceptions.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+
+class ScanError(Exception):
+    """Exception raised when an error while scanning occurs."""
+
+    def __init__(self: ScanError, msg: str) -> None:
+        super().__init__(msg)


### PR DESCRIPTION
Adds disconnect methods to scanners that close ports. They are called them when a scanner should stop or when it errors out.